### PR TITLE
Accept small matrix deviations in Rotation(matrix)

### DIFF
--- a/src/Base/Rotation.cpp
+++ b/src/Base/Rotation.cpp
@@ -221,7 +221,7 @@ void Rotation::setValue(const double q[4])
 void Rotation::setValue(const Matrix4D & m)
 {
     
-    auto type = m.hasScale();
+    auto type = m.hasScale(1e-7);
     if (type == Base::ScaleType::Other) {
         THROWM(Base::ValueError, "setValue(matrix): Could not determine the rotation.");
     }
@@ -270,7 +270,7 @@ void Rotation::setValue(const Matrix4D & m)
         this->quat[j] = ((mc[j][i] + mc[i][j]) * s);
         this->quat[k] = ((mc[k][i] + mc[i][k]) * s);
     }
-
+    this->normalize();
     this->evaluateVector();
 }
 


### PR DESCRIPTION
If the matrix passed to Rotation(matrix) is the result of many calculation steps, there is a risk it won't be accepted even though it should in theory behind calculations. Added a normalization to not spread the error further.
